### PR TITLE
feat: ドロワー検索のEnterキー実行とクリアボタンを追加

### DIFF
--- a/spa/src/components/Drawer.tsx
+++ b/spa/src/components/Drawer.tsx
@@ -78,6 +78,21 @@ export default function Drawer(props: DrawerProps): JSX.Element {
     onSearch(localSearchQuery);
   }, [localSearchQuery, onSearch]);
 
+  const handleSearchKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        onSearch(localSearchQuery);
+      }
+    },
+    [localSearchQuery, onSearch]
+  );
+
+  const handleClearSearch = useCallback((): void => {
+    setLocalSearchQuery("");
+    onSearch("");
+  }, [onSearch]);
+
   // メモを最終更新日時の降順でソート
   const sortedMemos: Memo[] = useMemo(() => {
     return [...memos].sort((a: Memo, b: Memo) => {
@@ -110,14 +125,43 @@ export default function Drawer(props: DrawerProps): JSX.Element {
             />
           </div>
           <div className="p-2 border-b border-base-300">
-            <input
-              type="text"
-              placeholder="Search..."
-              className="input input-bordered input-sm w-full"
-              value={localSearchQuery}
-              onChange={(e) => setLocalSearchQuery(e.target.value)}
-              onBlur={handleSearchBlur}
-            />
+            <div className="relative w-full">
+              <input
+                type="text"
+                placeholder="Search..."
+                className="input input-bordered input-sm w-full pr-8"
+                value={localSearchQuery}
+                onChange={(e) => setLocalSearchQuery(e.target.value)}
+                onBlur={handleSearchBlur}
+                onKeyDown={handleSearchKeyDown}
+              />
+              {localSearchQuery && (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  className="btn btn-ghost btn-xs btn-square absolute right-1 top-1/2 -translate-y-1/2"
+                  onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+                    e.preventDefault();
+                  }}
+                  onClick={handleClearSearch}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
           </div>
           <div className="flex-1 overflow-y-auto">
             <ul className="menu w-full p-0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

ドロワーのメモ検索用テキストボックスについて、検索を実行できるトリガーを追加します。これまではフォーカスを外した（onBlur）タイミングのみ検索を実行していましたが、以下の操作でも検索を実行するように修正します。

- テキストボックスにフォーカスしたまま `Enter` キーを押下したとき
- テキストボックス右側に追加した `x` ボタン（クリアボタン）を押下したとき（入力をすべて消去したうえで空文字で検索を実行）

## 変更内容

- `spa/src/components/Drawer.tsx`
  - `Enter` キー押下を検出する `handleSearchKeyDown` を追加し、`input` の `onKeyDown` に紐付け
  - 入力値を空にして空文字で検索を再実行する `handleClearSearch` を追加
  - テキストボックスを `relative` なラッパーで包み、入力値があるときのみ右側にクリア用 `x` ボタンを表示
  - クリアボタン押下時に `onBlur` の検索が二重実行されないよう、`onMouseDown` で `preventDefault` し、`onClick` でクリア処理を実行
  - 入力欄に右パディング (`pr-8`) を追加して、文字とクリアボタンが重ならないようレイアウト調整

## 技術的な詳細

- 既存の `onBlur` 経由の検索実行は維持し、後方互換を保っています。
- クリアボタンは入力値が空のときには表示しないため、レイアウトのちらつきを抑えるため `absolute` で重ねて配置しています。
- `Enter` キー押下時はフォームのデフォルト挙動（送信等）を抑止するため `preventDefault` を呼び出しています。

## テスト内容

### テスト観点表

| Case ID | Input / Precondition | Perspective (Equivalence / Boundary) | Expected Result | Notes |
|---|---|---|---|---|
| TC-N-01 | テキストボックスに任意の文字を入力後、フォーカスを外す | Equivalence – normal (既存仕様) | 入力値で `onSearch` が呼び出される | 既存挙動の回帰確認 |
| TC-N-02 | テキストボックスに任意の文字を入力後、フォーカス維持のまま `Enter` キー押下 | Equivalence – normal (新規仕様) | 入力値で `onSearch` が呼び出される | 新規挙動 |
| TC-N-03 | 入力値がある状態でクリアボタン (x) を押下 | Equivalence – normal (新規仕様) | 入力値が空になり、空文字で `onSearch` が呼び出される | 新規挙動 |
| TC-A-01 | 入力値が空の状態 | Boundary – 空 | クリアボタンが表示されない | レイアウト確認 |
| TC-A-02 | 入力値があり `Enter` 以外のキー（例: `a`, `Shift` 等）を押下 | Equivalence – 異常系 | `onSearch` は呼び出されない | 不要な検索実行が起きないこと |
| TC-A-03 | クリアボタンを押下した直後に `onBlur` が発火しうるケース | Boundary – イベント順序 | クリアボタンの `onClick` 後に `onBlur` で重複検索が走らないこと | `onMouseDown` で `preventDefault` |

### 確認方法

- `npm run lint` を実行し、Lint エラーがないことを確認
- `npm run build` を実行し、TypeScript の型エラー・ビルドエラーがないことを確認

実行コマンド:

```bash
cd spa
npm run lint
npm run build
```

自動テストは本リポジトリに導入されていないため、追加していません。挙動確認は実機（ブラウザ）での手動確認を想定しています。

## 関連Issue

- なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-729db070-7c5c-4064-9daf-c9963e94c085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-729db070-7c5c-4064-9daf-c9963e94c085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

