### PR TITLE
docs: AGENTS.md にCursor Cloud向け開発環境情報を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### サービス概要
+
+MarkdownNotePortal — Markdown形式でメモを管理するWebアプリケーション。React SPA（`spa/`）+ AWS Lambda バックエンド（`lambdas/`）+ DynamoDB の構成。ローカル開発ではDockerで Lambda と DynamoDB Local をエミュレートする。
+
+### サービス起動手順
+
+ローカル開発では以下の2つのサービスを起動する必要がある（詳細は `localsetup.md` 参照）:
+
+1. **バックエンド（Docker Compose）**: Lambda関数のビルド後に `docker compose up` で DynamoDB Local + 5つのLambda関数コンテナを起動
+2. **フロントエンド（Vite dev server）**: `cd spa && npm run dev` でポート5173に開発サーバーを起動
+
+### 注意事項・Gotcha
+
+- **DynamoDB Local の権限問題**: `docker/dynamodb/` ディレクトリに書き込み権限が必要。初回起動時に `mkdir -p docker/dynamodb && chmod 777 docker/dynamodb` を実行すること。権限が不足すると DynamoDB Local が SQLite エラーで起動に失敗する。
+- **Lambda ビルドが必須**: Docker Compose で Lambda コンテナを起動する前に `cd lambdas && npm run build` が必要（`lambdas/dist/` をボリュームマウントしているため）。
+- **ローカル認証は無効**: ローカル環境では Cognito 認証がバイパスされ、`Authorization` ヘッダーの検証も行わない。
+- **パッケージマネージャー**: npm を使用（`package-lock.json` が `lambdas/` と `spa/` の両方に存在）。
+
+### Lint・テスト・ビルドコマンド
+
+`CONTRIBUTING.md` を参照。主要なコマンド:
+
+- `cd lambdas && npm run lint` — Lambda関数のESLint
+- `cd lambdas && npm run test` — Lambda関数のVitest（カバレッジ80%以上が必要）
+- `cd lambdas && npm run build` — Lambda関数のビルド（Viteベース）
+- `cd spa && npm run lint` — SPAのESLint
+- `cd spa && npm run dev` — Vite開発サーバー（ポート5173）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud Agent向けの開発環境セットアップ情報を `AGENTS.md` に追加。

## 変更内容

- `AGENTS.md` を新規作成し、以下の情報を記載:
  - サービス概要（React SPA + AWS Lambda + DynamoDB）
  - ローカル開発でのサービス起動手順
  - DynamoDB Local の権限問題など注意事項・Gotcha
  - Lint・テスト・ビルドコマンドのリファレンス

## テスト内容

- ✅ `cd lambdas && npm run lint` — ESLintエラーなし
- ✅ `cd spa && npm run lint` — ESLintエラーなし
- ✅ `cd lambdas && npm run test` — 59テスト全パス（カバレッジ93.96%）
- ✅ `cd lambdas && npm run build` — ビルド成功
- ✅ `docker compose up` — DynamoDB Local + 5 Lambda コンテナ起動確認
- ✅ `cd spa && npm run dev` — Vite開発サーバー起動確認（ポート5173）
- ✅ ブラウザからメモの作成・表示を手動確認

[demo_memo_crud.mp4](https://cursor.com/agents/bc-8756d71b-7152-47e3-ada5-62a9480e26d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_memo_crud.mp4)
[メモ作成完了](https://cursor.com/agents/bc-8756d71b-7152-47e3-ada5-62a9480e26d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmemo_created.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8756d71b-7152-47e3-ada5-62a9480e26d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8756d71b-7152-47e3-ada5-62a9480e26d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

