### PR TITLE
fix: タイトルバーで長いタイトルを折り返さず1行で表示

### DIFF
--- a/spa/src/components/Header.tsx
+++ b/spa/src/components/Header.tsx
@@ -35,7 +35,7 @@ export default function Header(props: HeaderProps): JSX.Element {
           isDrawerOpen={isDrawerOpen}
         />
       </div>
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <TitleEditor
           title={title}
           hasSelectedMemo={hasSelectedMemo}

--- a/spa/src/components/TitleEditor.tsx
+++ b/spa/src/components/TitleEditor.tsx
@@ -97,14 +97,14 @@ export default function TitleEditor(props: TitleEditorProps): JSX.Element {
       onChange={handleTitleChange}
       onKeyDown={handleKeyDown}
       autoComplete="off"
-      className="input input-bordered input-sm w-full max-w-md text-xl font-bold mx-4"
+      className="input input-bordered input-sm w-full min-w-0 max-w-full text-xl font-bold mx-4"
     />
   ) : (
     <h1
       ref={(node) => {
         containerRef.current = node;
       }}
-      className={`text-xl font-bold px-4 transition-colors ${
+      className={`min-w-0 w-full truncate text-xl font-bold px-4 transition-colors ${
         hasSelectedMemo ? "cursor-pointer hover:text-primary" : "cursor-default"
       }`}
       onClick={handleTitleClick}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

横長レイアウトでメモタイトルが長い場合、ヘッダー内のタイトルが複数行に折り返され、ナビゲーションバーの高さが不必要に増える問題を修正しました。編集モード以外では1行に収め、はみ出しは省略記号で示します。

## 変更内容

- `Header.tsx` のタイトル用 `flex-1` コンテナに `min-w-0` を追加し、flex 子要素が親幅に収まるようにした（長文時の折り返しの前提となる幅の収縮を有効化）
- `TitleEditor.tsx` の非編集時の `h1` に `min-w-0`・`w-full`・`truncate`（`overflow-hidden` / `text-ellipsis` / `whitespace-nowrap`）を適用し、1行表示＋省略に統一
- 編集時の `input` から `max-w-md` を外し `min-w-0 max-w-full` とし、利用可能なヘッダー幅いっぱいで長文を編集できるようにした

## テスト内容

- `cd spa && npm run lint` を実行し、エラーがないことを確認した
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a065cf98-2b12-4b3d-b4c3-df30bc9c6963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a065cf98-2b12-4b3d-b4c3-df30bc9c6963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

