### PR TITLE
fix: Drawer検索後のメモ選択が先頭に戻る不具合を修正

### DIFF
--- a/spa/src/components/AuthenticatedDisplay.tsx
+++ b/spa/src/components/AuthenticatedDisplay.tsx
@@ -58,12 +58,20 @@ export default function AuthenticatedDisplay(): JSX.Element {
       }));
       setMemos(fetchedMemos);
 
-      // メモが存在する場合は最初のメモを選択
-      if (fetchedMemos.length > 0) {
-        setSelectedMemoId(fetchedMemos[0].id);
-      } else {
-        setSelectedMemoId(null);
-      }
+      // 一覧取得後は、既に選択中のメモが結果に含まれる場合はそのまま維持する。
+      // （検索入力の blur で一覧が再取得されたとき、クリックで選んだメモが先頭に上書きされるのを防ぐ）
+      setSelectedMemoId((currentId: string | null) => {
+        if (fetchedMemos.length === 0) {
+          return null;
+        }
+        if (
+          currentId !== null &&
+          fetchedMemos.some((m: Memo) => m.id === currentId)
+        ) {
+          return currentId;
+        }
+        return fetchedMemos[0].id;
+      });
     } catch (error) {
       setErrorMessage(getErrorMessage(error, "Failed to load memos"));
       if (isUnauthorizedApiError(error)) {

--- a/spa/src/components/Drawer.tsx
+++ b/spa/src/components/Drawer.tsx
@@ -75,8 +75,11 @@ export default function Drawer(props: DrawerProps): JSX.Element {
   }, []);
 
   const handleSearchBlur = useCallback((): void => {
-    onSearch(localSearchQuery);
-  }, [localSearchQuery, onSearch]);
+    // 親と同じクエリなら再検索しない（メモクリックで入力が blur したときの二重取得と選択のちらつきを防ぐ）
+    if (localSearchQuery !== searchQuery) {
+      onSearch(localSearchQuery);
+    }
+  }, [localSearchQuery, onSearch, searchQuery]);
 
   const handleSearchKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

検索で Enter したあと、一覧の先頭以外のメモをクリックしても Workspace では先頭メモが開いてしまう問題を修正しました。

## 変更内容

- `AuthenticatedDisplay` の `loadMemos` 完了時に、常に先頭メモへ `selectedMemoId` を付け替えていた処理をやめ、取得結果に現在の選択 ID が含まれるときはそのまま維持するようにしました。
- `Drawer` の検索入力 `onBlur` で、親の `searchQuery` と `localSearchQuery` が一致するときは `onSearch` を呼ばないようにし、メモクリック時に入力が blur して同じ条件で一覧が再取得されないようにしました（不要な API 呼び出しと状態競合の防止）。

## 技術的な詳細（任意）

- 原因: メモ行クリックの直前に検索欄が blur し、`onSearch` → `loadMemos` が再度走る。非同期の `loadMemos` 完了時に `setSelectedMemoId(fetchedMemos[0].id)` が実行され、クリックで設定した ID が上書きされていた。
- `setSelectedMemoId` は関数型更新にし、完了時点の選択と取得結果の積集合を優先するようにした。

## テスト内容

- `cd spa && npm run lint` を実行し、エラーがないことを確認した。
- SPA に既存の自動テストはないため、手動で「検索 → Enter → 先頭以外のメモをクリック」の手順を確認することを推奨する。

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-443e59e0-5ac2-4239-80aa-a25af4a980af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-443e59e0-5ac2-4239-80aa-a25af4a980af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

