### PR TITLE
fix: フォーマット後に⌘+Z/Ctrl+Zで本文を元に戻せるようにする

### DIFF
--- a/spa/src/components/AuthenticatedDisplay.tsx
+++ b/spa/src/components/AuthenticatedDisplay.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LayoutMode, Memo, SaveStatus } from "../types/state";
 import {
   createMemo,
@@ -39,6 +39,8 @@ export default function AuthenticatedDisplay(): JSX.Element {
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("horizontal");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isFormatting, setIsFormatting] = useState<boolean>(false);
+
+  const markdownEditorRef = useRef<HTMLTextAreaElement>(null);
 
   // 選択されたメモを取得
   const selectedMemo: Memo | undefined = useMemo<Memo | undefined>(
@@ -316,33 +318,46 @@ export default function AuthenticatedDisplay(): JSX.Element {
         selectedMemo.content,
       );
 
-      // フォーマットされたコンテンツで状態を更新
-      setMemos((prevMemos: Memo[]) =>
-        prevMemos.map((memo: Memo) =>
-          memo.id === selectedMemoId
-            ? { ...memo, content: formattedContent.trim() }
-            : memo,
-        ),
-      );
+      const trimmed = formattedContent.trim();
+      const ta = markdownEditorRef.current;
 
-      // 既存のタイマーをキャンセル
-      if (autoSaveTimer) {
-        clearTimeout(autoSaveTimer);
+      const applyContentViaReactState = (): void => {
+        setMemos((prevMemos: Memo[]) =>
+          prevMemos.map((memo: Memo) =>
+            memo.id === selectedMemoId
+              ? { ...memo, content: trimmed }
+              : memo,
+          ),
+        );
+
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer);
+        }
+
+        const timer = setTimeout(() => {
+          setMemos((currentMemos: Memo[]) => {
+            const currentMemo = currentMemos.find(
+              (memo: Memo) => memo.id === selectedMemoId,
+            );
+            if (currentMemo && currentMemo.content !== undefined) {
+              saveMemo(selectedMemoId, currentMemo.title, currentMemo.content);
+            }
+            return currentMemos;
+          });
+        }, 3000);
+        setAutoSaveTimer(timer);
+      };
+
+      // insertText はブラウザの Undo 履歴に載る。React の state だけを更新すると Ctrl+Z / ⌘+Z が効かない。
+      if (ta !== null && typeof document.execCommand === "function") {
+        ta.focus();
+        ta.setSelectionRange(0, ta.value.length);
+        if (document.execCommand("insertText", false, trimmed)) {
+          return;
+        }
       }
 
-      // 3秒後に自動保存
-      const timer = setTimeout(() => {
-        setMemos((currentMemos: Memo[]) => {
-          const currentMemo = currentMemos.find(
-            (memo: Memo) => memo.id === selectedMemoId,
-          );
-          if (currentMemo && currentMemo.content !== undefined) {
-            saveMemo(selectedMemoId, currentMemo.title, currentMemo.content);
-          }
-          return currentMemos;
-        });
-      }, 3000);
-      setAutoSaveTimer(timer);
+      applyContentViaReactState();
     } catch (error) {
       setErrorMessage(getErrorMessage(error, "Failed to format markdown"));
     } finally {
@@ -387,6 +402,7 @@ export default function AuthenticatedDisplay(): JSX.Element {
         layoutMode={layoutMode}
         isLoadingMemos={isLoadingMemos}
         isLoadingMemoDetail={isLoadingMemoDetail}
+        markdownEditorRef={markdownEditorRef}
         onClickNewMemoButton={handleAddMemo}
         saveMemo={saveMemo}
         selectedMemo={selectedMemo}

--- a/spa/src/components/Workspace.tsx
+++ b/spa/src/components/Workspace.tsx
@@ -34,6 +34,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     selectedMemoId,
     setAutoSaveTimer,
     setMemos,
+    markdownEditorRef,
   } = props;
 
   const [editorWidthPercent, setEditorWidthPercent] = useState<number>(50);
@@ -170,6 +171,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           <>
             <WorkspaceEditor
               markdownContent={selectedMemo.content ?? ""}
+              markdownEditorRef={markdownEditorRef}
               onChange={handleMarkdownContentChange}
               layoutMode={layoutMode}
               widthPercent={editorWidthPercent}

--- a/spa/src/components/WorkspaceEditor.tsx
+++ b/spa/src/components/WorkspaceEditor.tsx
@@ -9,7 +9,8 @@ import type { WorkspaceEditorProps } from "../types/props";
 export default function WorkspaceEditor(
   props: WorkspaceEditorProps
 ): JSX.Element {
-  const { layoutMode, markdownContent, onChange, widthPercent } = props;
+  const { layoutMode, markdownContent, markdownEditorRef, onChange, widthPercent } =
+    props;
 
   return (
     <div
@@ -21,6 +22,7 @@ export default function WorkspaceEditor(
       }
     >
       <textarea
+        ref={markdownEditorRef}
         className="flex-1 w-full p-4 font-mono text-sm resize-none focus:outline-none"
         value={markdownContent}
         onChange={onChange}

--- a/spa/src/types/props.ts
+++ b/spa/src/types/props.ts
@@ -1,4 +1,9 @@
-import type { ChangeEvent, Dispatch, SetStateAction } from "react";
+import type {
+  ChangeEvent,
+  Dispatch,
+  RefObject,
+  SetStateAction,
+} from "react";
 import type { LayoutMode, Memo, SaveStatus } from "./state";
 
 /**
@@ -347,6 +352,11 @@ export interface WorkspaceProps {
    * メモ一覧を更新する関数
    */
   setMemos: Dispatch<SetStateAction<Memo[]>>;
+
+  /**
+   * Markdownエディター（textarea）への参照（フォーマット後のUndo用）
+   */
+  markdownEditorRef: RefObject<HTMLTextAreaElement | null>;
 }
 
 /**
@@ -367,6 +377,11 @@ export interface WorkspaceEditorProps {
    * Markdownコンテンツを変更する関数
    */
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+
+  /**
+   * textarea 要素への参照（親から execCommand 等で操作する場合に使用）
+   */
+  markdownEditorRef: RefObject<HTMLTextAreaElement | null>;
 
   /**
    * エディターのサイズ(画面のパーセンテージ)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Format 実行後に React の state だけで `textarea` の `value` を差し替えていたため、ブラウザネイティブの編集 Undo 履歴に載らず、⌘+Z（macOS）や Ctrl+Z（Windows）でフォーマット前の本文に戻せませんでした。整形結果を `document.execCommand("insertText")` で反映するよう変更し、通常のテキスト編集と同様に Undo できるようにしました。

## 変更内容

- `AuthenticatedDisplay` に `markdownEditorRef` を追加し、`Workspace` → `WorkspaceEditor` の `textarea` に接続した
- `handleFormatMarkdown` で API から取得した整形済み本文を、`textarea` 全選択のうえ `insertText` で挿入する（これによりブラウザの Undo スタックに置換が記録される）
- `insertText` が失敗する環境では従来どおり `setMemos` で状態を更新するフォールバックを維持した
- `insertText` が成功した場合は `onChange`（`Workspace` 内のハンドラ）が自動保存タイマーを再スケジュールするため、従来の `setMemos` 直書きと二重にならないよう整理した

## テスト内容

- `cd spa && npm run lint` を実行し、問題ないことを確認した
- `cd spa && npm run build`（`tsc -b` 含む）を実行し、型チェックと本番ビルドが通ることを確認した
- ブラウザ上の手動 E2E（Format → ⌘+Z）は本環境では未実施（`insertText` は Chromium 系で一般的に Undo 可能）

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76a3bd6f-0002-4146-8030-4ad4b6ed5632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76a3bd6f-0002-4146-8030-4ad4b6ed5632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

