### PR TITLE
docs: クラウド開発環境の更新と起動手順・注意事項の整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,17 @@ MarkdownNotePortal — Markdown形式でメモを管理するWebアプリケー�
 
 ローカル開発では以下の2つのサービスを起動する必要がある（詳細は `localsetup.md` 参照）:
 
-1. **バックエンド（Docker Compose）**: Lambda関数のビルド後に `docker compose up` で DynamoDB Local + 6つのLambda関数コンテナを起動
-2. **フロントエンド（Vite dev server）**: `cd spa && npm run dev` でポート5173に開発サーバーを起動
+1. **Docker デーモンの起動**: このVMには systemd がないため、Docker は自動起動しない。バックエンド起動前に一度だけ `sudo dockerd > /tmp/dockerd.log 2>&1 &`（バックグラウンド）で起動しておく。`sudo docker info` で `Server Version` が返れば起動済み。
+2. **バックエンド（Docker Compose）**: Lambda関数のビルド後に `docker compose up -d` で DynamoDB Local + 6つのLambda関数コンテナ（ポート9000〜9006）を起動。テーブル `mkmemoportal-dynamodb` は起動時に自動作成される。
+3. **フロントエンド（Vite dev server）**: `cd spa && npm run dev` でポート5173に開発サーバーを起動。`http://localhost:5173` にアクセスするとメモの新規作成・編集は**自動保存**される（明示的な保存ボタンはない）。
 
 ### 注意事項・Gotcha
 
+- **Node.js は v24 が必須**: プロジェクトは Node 24（`public.ecr.aws/lambda/nodejs:24` と `@types/node@^24`）を前提とする。このVMでは非対話シェルの `PATH` 先頭に `/exec-daemon/node`（v22）が割り込むため、素の `node` が v22 になることがある。Node 24 は nvm で導入済み（`nvm alias default` が 24、`~/.bashrc` で対話シェルの先頭 `PATH` に前置済み）。ビルド/実行前に `node -v` が v24 であることを確認し、v22 なら `source ~/.nvm/nvm.sh && nvm use 24` で切り替える。
+- **`npm install` を Node 22 で実行しない**: Node 22（npm 10）で `npm install` すると `package-lock.json` から `libc` フィールドが除去され差分が発生する。依存の再取得はロックファイルを書き換えない `npm ci`（起動時の update script でも使用）で行うこと。
+- **Docker 29 + fuse-overlayfs 設定**: このVMではカーネル制約のため `/etc/docker/daemon.json` で `storage-driver=fuse-overlayfs` かつ `features.containerd-snapshotter=false`、iptables は legacy を使用する（設定済み・スナップショットに保持）。この設定なしでは dockerd が起動しない。
 - **DynamoDB Local の権限問題**: `docker/dynamodb/` ディレクトリに書き込み権限が必要。初回起動時に `mkdir -p docker/dynamodb && chmod 777 docker/dynamodb` を実行すること。権限が不足すると DynamoDB Local が SQLite エラーで起動に失敗する。
-- **Lambda ビルドが必須**: Docker Compose で Lambda コンテナを起動する前に `cd lambdas && npm run build` が必要（`lambdas/dist/` をボリュームマウントしているため）。
+- **Lambda ビルドが必須**: Docker Compose で Lambda コンテナを起動する前に `cd lambdas && npm run build` が必要（`lambdas/dist/` をボリュームマウントしているため）。ビルドは Node 24 で実行すること。
 - **ローカル認証は無効**: ローカル環境では Cognito 認証がバイパスされ、`Authorization` ヘッダーの検証も行わない。
 - **パッケージマネージャー**: npm を使用（`package-lock.json` が `lambdas/` と `spa/` の両方に存在）。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

ダッシュボード管理のクラウド開発環境（スナップショット方式）を最新の依存関係・ツールで更新し、`MarkdownNotePortal` をエンドツーエンドで起動・検証した。あわせて、将来のエージェントが安全にサービスを起動できるよう、非自明な起動手順・注意事項を `AGENTS.md` に追記した。既存の動作は維持している（コード・ロックファイルの変更なし）。

## 変更内容

- `AGENTS.md` の `## Cursor Cloud specific instructions` に以下の非自明な情報を追記:
  - Docker デーモンを手動起動する必要がある旨（このVMには systemd がないため `sudo dockerd &` が必要）
  - Node.js v24 が必須である旨と、非対話シェルで `/exec-daemon/node`（v22）が `PATH` 先頭に割り込む gotcha、および nvm での切り替え方法
  - Node 22（npm 10）での `npm install` が `package-lock.json` の `libc` フィールドを除去するため、再取得は `npm ci` を用いる旨
  - Docker 29 + fuse-overlayfs / `containerd-snapshotter=false` の必須設定（設定済み）
  - メモが自動保存される点の補足

## 技術的な詳細

- **環境更新スクリプト（VM起動時の依存リフレッシュ）**: `npm ci --prefix lambdas` / `npm ci --prefix spa` の最小構成に設定。`npm ci` はロックファイルを書き換えないため、Node バージョンに依存せず既存の動作を保持する。
- **システム依存（スナップショットに保持）**: Node.js v24（nvm で導入・default 化）、Docker Engine 29 + Compose v2 プラグイン（dind ワークアラウンド: fuse-overlayfs + iptables-legacy + `containerd-snapshotter=false`）。これらは更新スクリプトには含めない。
- コード本体・`package.json`・`package-lock.json` は未変更。

## テスト内容

- **Lint**: `cd lambdas && npm run lint` / `cd spa && npm run lint` — いずれも成功（エラー0）。
- **ユニットテスト**: `cd lambdas && npm run test` — 8ファイル / 68テスト成功、Statements 94.05% / Lines 94.01%（カバレッジ閾値クリア）。
- **ビルド**: `cd lambdas && npm run build` — 全ハンドラを `dist/` に生成し成功。
- **バックエンド起動**: `docker compose up -d` で DynamoDB Local + Lambda 6コンテナが起動、テーブル `mkmemoportal-dynamodb` を自動作成。RIE への直接呼び出しおよび Vite プロキシ経由の `POST/GET/DELETE /memo` を確認。
- **フロントエンド起動 + E2E（Hello World）**: Vite dev server（`:5173`）を起動し、ブラウザでメモ「Hello Cloud Env」を新規作成。Markdown プレビュー（見出し・太字・箇条書き）のレンダリングと自動保存、一覧表示、DynamoDB への永続化を確認。

## 関連Issue

- なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ace4667-fc3a-4ee0-a4ca-2539087c8a1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ace4667-fc3a-4ee0-a4ca-2539087c8a1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

